### PR TITLE
fix(ddev): install orchestrate addon + pin reusable workflows

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -4,4 +4,4 @@ docroot: .ddev/wordpress
 php_version: "8.4"
 hooks:
     pre-start:
-        - exec-host: ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true
+        - exec-host: ddev add-on get apermo/ddev-orchestrate -y 2>/dev/null || true

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -4,4 +4,4 @@ docroot: .ddev/wordpress
 php_version: "8.4"
 hooks:
     pre-start:
-        - exec-host: ddev add-on get apermo/ddev-orchestrate -y 2>/dev/null || true
+        - exec-host: ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -2,3 +2,6 @@ name: site-bookkeeper-reporter
 type: php
 docroot: .ddev/wordpress
 php_version: "8.4"
+hooks:
+    pre-start:
+        - exec-host: ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,6 @@
 /e2e/               export-ignore
 /playwright.config.js export-ignore
 /package.json       export-ignore
+/.wp-env.json       export-ignore
 CHANGELOG.md        export-ignore
 CLAUDE.md           export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     ci:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-ci.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-ci.yml@v0.4.3
         with:
             php-versions: '["8.2", "8.3", "8.4"]'
             test-command: 'test:unit'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     ci:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-ci.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-ci.yml@v0.4
         with:
             php-versions: '["8.2", "8.3", "8.4"]'
             test-command: 'test:unit'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
     e2e:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-e2e.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-e2e.yml@v0.4.3
         with:
             wp-versions: '["latest"]'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
     e2e:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-e2e.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-e2e.yml@v0.4
         with:
             wp-versions: '["latest"]'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
 
     integration:
         needs: detect-wp-minimum
-        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@v0.4.3
         with:
             php-versions: >-
                 ${{ github.event_name == 'push'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
 
     integration:
         needs: detect-wp-minimum
-        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@v0.4
         with:
             php-versions: >-
                 ${{ github.event_name == 'push'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
     pr-validation:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-pr-validation.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-pr-validation.yml@v0.4.3
         permissions:
             contents: read
             pull-requests: write
     conventional-commits:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.4.3

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
     pr-validation:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-pr-validation.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-pr-validation.yml@v0.4
         permissions:
             contents: read
             pull-requests: write
     conventional-commits:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     prerelease:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-prerelease.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-prerelease.yml@v0.4.3
         permissions:
             contents: write
             pull-requests: write

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     prerelease:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-prerelease.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-prerelease.yml@v0.4
         permissions:
             contents: write
             pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
     conventional-commits:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.4.3
     release:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-release.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-release.yml@v0.4.3
         permissions:
             contents: write
             pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
     conventional-commits:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-conventional-commits.yml@v0.4
     release:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-release.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-release.yml@v0.4
         permissions:
             contents: write
             pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     stale:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.4.3
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     stale:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.4
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/wp-beta.yml
+++ b/.github/workflows/wp-beta.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     beta:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@main
+        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@v0.4.3
         with:
             php-versions: '["8.3","8.4"]'
             wp-versions: '["beta"]'

--- a/.github/workflows/wp-beta.yml
+++ b/.github/workflows/wp-beta.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     beta:
-        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@v0.4.3
+        uses: apermo/reusable-workflows/.github/workflows/reusable-wp-integration.yml@v0.4
         with:
             php-versions: '["8.3","8.4"]'
             wp-versions: '["beta"]'

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,6 @@
+{
+    "plugins": ["."],
+    "config": {
+        "WP_DEBUG": true
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] - 2026-04-18
 
 ### Fixed
 
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overdue detection and admin notices
 - E2E and unit test suites
 
+[0.1.3]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/apermo/site-bookkeeper-reporter/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- DDEV `orchestrate` command failing on fresh clones and in CI by installing
+  the `apermo/ddev-orchestrate` addon via a `pre-start` hook (#22)
+
+### Changed
+
+- Pinned reusable GitHub Actions workflows to `v0.4.3` (previously tracked `main`)
+
 ## [0.1.2] - 2026-04-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DDEV `orchestrate` command failing on fresh clones and in CI by installing
   the `apermo/ddev-orchestrate` addon via a `pre-start` hook (#22)
 
+### Added
+
+- `.wp-env.json` for the E2E workflow to boot `wp-env` against the plugin
+
 ### Changed
 
 - Pinned reusable GitHub Actions workflows to the floating `v0.4` tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Pinned reusable GitHub Actions workflows to `v0.4.3` (previously tracked `main`)
+- Pinned reusable GitHub Actions workflows to the floating `v0.4` tag
+  (previously tracked `main`)
 
 ## [0.1.2] - 2026-04-05
 

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Site Bookkeeper Reporter
  * Description: Pushes site health data to a central monitoring hub.
- * Version:     0.1.1
+ * Version:     0.1.3
  * Author:      Christoph Daum
  * Author URI:  https://apermo.de
  * License:     GPL-2.0-or-later

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,7 +9,7 @@ namespace Apermo\SiteBookkeeperReporter;
  */
 class Plugin {
 
-	public const VERSION = '0.1.2';
+	public const VERSION = '0.1.3';
 
 	/**
 	 * Main plugin file path.


### PR DESCRIPTION
## Summary

- Install the `apermo/ddev-orchestrate` addon via a `pre-start` hook so `ddev orchestrate` works on fresh clones and in CI (closes #22)
- Pin all callers of `apermo/reusable-workflows` from `@main` to the floating `@v0.4` tag for reproducible CI
- Add `.wp-env.json` required by the reusable E2E workflow
- Bump to `v0.1.3` (plugin header, `Plugin::VERSION`, CHANGELOG)

## Test plan

- [x] CI runs green on this PR (24/24 checks SUCCESS on `3b04c0a`)
- [x] `rm -rf .ddev/commands .ddev/orchestrate .ddev/addon-metadata && ddev start` succeeds locally and reinstalls the addon via the pre-start hook
- [x] `ddev orchestrate` runs after `ddev start` without the "unknown command" error