### PR TITLE
chore(stale): never auto-close stale items

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,9 @@ on:
 jobs:
     stale:
         uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.4
+        with:
+            # -1 means never close, only mark as stale.
+            days-before-close: -1
         permissions:
             issues: write
             pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-08-18
+
+### Changed
+
+- Stale bot no longer auto-closes inactive issues and pull requests; they are
+  still marked stale (`days-before-close: -1`)
+
 ## [0.1.3] - 2026-04-18
 
 ### Fixed
@@ -60,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overdue detection and admin notices
 - E2E and unit test suites
 
+[0.1.4]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/apermo/site-bookkeeper-reporter/compare/v0.1.0...v0.1.1

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Site Bookkeeper Reporter
  * Description: Pushes site health data to a central monitoring hub.
- * Version:     0.1.3
+ * Version:     0.1.4
  * Author:      Christoph Daum
  * Author URI:  https://apermo.de
  * License:     GPL-2.0-or-later


### PR DESCRIPTION
Adds a `with:` block to the `stale` job passing `days-before-close: -1`, which is `actions/stale`s documented value for "mark as stale, never close".

## Why at the call site

This repo pins the reusable workflow at `apermo/reusable-workflows/.github/workflows/reusable-stale.yml@v0.4`. A tag reference resolves to that immutable commit, so the corresponding fix on the shared workflows `main` branch will never reach this repo. The override therefore has to be passed by the caller.

`v0.4` declares the input as the older singular `days-before-close` (not the newer `days-before-issue-close` / `days-before-pr-close` pair), so that is the name used here.

## Scope

- Tag reference left pinned at `@v0.4` on purpose; not bumped or unpinned.
- Schedule (`0 6 * * *`) and `permissions` unchanged.

## Release

Version bumped to `0.1.4` (`CHANGELOG.md`, `plugin.php` header) because
`pr-validation` requires an unreleased CHANGELOG entry and `0.1.3` is
already tagged.
